### PR TITLE
[APIS-818] revised: PHP driver build and release for linux PHP version 7.3.x

### DIFF
--- a/php_cubrid7.c
+++ b/php_cubrid7.c
@@ -2655,7 +2655,12 @@ ZEND_FUNCTION(cubrid_put)
 					attr_type[i] = CCI_A_TYPE_STR;
 					break;
 				case IS_ARRAY:
-					cubrid_retval = cubrid_make_set(HASH_OF(data), &temp_set);
+					if (!data || Z_ARRLEN_P(data) == 0) {
+						cubrid_retval = 0;
+					}
+					else {
+						cubrid_retval = cubrid_make_set(HASH_OF(data), &temp_set);
+					}
 					if (cubrid_retval < 0) {
 						handle_error(cubrid_retval, NULL, connect);
 						goto ERR_CUBRID_PUT;
@@ -2721,7 +2726,12 @@ ZEND_FUNCTION(cubrid_put)
 
 			break;
 		case IS_ARRAY:
-			cubrid_retval = cubrid_make_set(HASH_OF(attr_value), &temp_set);
+			if (!data || Z_ARRLEN_P(data) == 0) {
+				cubrid_retval = 0;
+			}
+			else {
+				cubrid_retval = cubrid_make_set(HASH_OF(attr_value), &temp_set);
+			}
 			if (cubrid_retval < 0) {
 				handle_error(cubrid_retval, NULL, connect);
 				goto ERR_CUBRID_PUT;

--- a/php_cubrid7.h
+++ b/php_cubrid7.h
@@ -43,6 +43,8 @@
 # define GC_DELREF(p) (GC_REFCOUNT(p)--)
 #endif
 
+#define Z_ARRLEN_P(v) zend_hash_num_elements(Z_ARRVAL_P(v))
+
 #ifdef PHP_WIN32
 #   define PHP_CUBRID_API __declspec(dllexport)
 #elif defined(__GNUC__) && __GNUC__ >= 4


### PR DESCRIPTION
the Zend framework was modified to dump core on PHP version 7.3 or later.
CUBRID PHP driver code should also modified to check array length of the parameter resource.
