### PR TITLE
[APIS-819] PHP driver build and release for linux PHP version 7.4.x

### DIFF
--- a/php_cubrid_version.h
+++ b/php_cubrid_version.h
@@ -28,4 +28,4 @@
  *
  */
 
-#define PHP_CUBRID_VERSION "10.2.0.0002"
+#define PHP_CUBRID_VERSION "10.2.0.0003"


### PR DESCRIPTION
Driver code is not changed for PHP version 7.4.x, but the build number has to be increased for release.